### PR TITLE
Add migration for 0.2.1

### DIFF
--- a/overlay/usr/local/migration/0.2.1.sh
+++ b/overlay/usr/local/migration/0.2.1.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Running migration for 0.2.1"
+
+pip install -r /usr/local/bazarr/requirements.txt

--- a/post_update.sh
+++ b/post_update.sh
@@ -2,5 +2,6 @@
 
 ./usr/local/migration/0.1.0.sh
 ./usr/local/migration/0.2.0.sh
+./usr/local/migration/0.2.1.sh
 
 sysrc -f /etc/rc.conf bazarr_enable="YES"


### PR DESCRIPTION
Related to bazarr issue: https://github.com/morpheus65535/bazarr/issues/1087

As there is a new requirement install it in the migration script.